### PR TITLE
# Add SetValue method in context to set context.values outside contex…

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -711,6 +711,10 @@ type Context interface {
 	// 		return u, ok
 	// 	}
 	Value(key interface{}) interface{}
+
+	// SetValue stores the key-value in this context.
+	// To pass data between middleware and middleware or middleware and handle
+	SetValue(key string, value interface{})
 }
 
 // Next calls all the next handler from the handlers chain,
@@ -2330,7 +2334,11 @@ func (ctx *context) Value(key interface{}) interface{} {
 		return ctx.request
 	}
 	if k, ok := key.(string); ok {
-		return ctx.values.GetString(k)
+		return ctx.values.Get(k)
 	}
 	return nil
+}
+
+func (ctx *context) SetValue(key string, value interface{})  {
+	ctx.values.Set(key, value)
 }


### PR DESCRIPTION
In my project, I want to pass data from middleware to a handle function.  I read the context.go.  In context struct, there is a attribute named values can implement it. But in Content interface(content
struct have implemented Content interface), There is no way to set values or modify values outside 
context package. So, I want to add a method to do it. 

And In "func (ctx *context) Value(key interface{}) interface{}", "ctx.values.GetString(k)" can only get
value of string type and in fact it may be other type.